### PR TITLE
Remove concat query param

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,6 @@ import dataRouter from "./components/chatbot/data/dataApi.js";
 import gptRouter from "./components/chatbot/gpt/gptApi.js";
 import campaignRouter from "./components/campaign/campaignApi.js";
 import companyTagRouter from "./components/company/tag/tagApi.js";
-import tagSubscriptionRouter from "./components/customer/tagSubscription/tagSubscriptionApi.js";
 import tokenRouter from "./components/token/tokenApi.js";
 
 dotenv.config();
@@ -58,7 +57,6 @@ app.use("/api/train-data", dataRouter);
 app.use("/api/model", gptRouter);
 app.use("/api/campaign", campaignRouter);
 app.use("/api/company/tag", companyTagRouter);
-app.use("/api/customer/tag", tagSubscriptionRouter);
 app.use("/api/token", tokenRouter);
 
 app.get("/", (req, res) => {

--- a/src/components/customer/customerApi.js
+++ b/src/components/customer/customerApi.js
@@ -6,6 +6,7 @@ import {
 } from "./customerController.js";
 import { verifyToken } from "../../middlewares/verifyToken.js";
 import { verifyCustomerId } from "./customerMiddleware.js";
+import tagSubscriptionRouter from "./tagSubscription/tagSubscriptionApi.js";
 
 const customerRouter = express.Router({ mergeParams: true });
 
@@ -13,6 +14,8 @@ customerRouter.use("/", (req, res, next) => {
   // #swagger.tags = ['Customer']
   next();
 });
+
+customerRouter.use("/tag", tagSubscriptionRouter);
 
 customerRouter.use("/", verifyToken(true));
 customerRouter.get("/", getCustomers);

--- a/src/components/customer/tagSubscription/tagSubscriptionApi.js
+++ b/src/components/customer/tagSubscription/tagSubscriptionApi.js
@@ -10,13 +10,9 @@ tagRouter.use("/", (req, res, next) => {
   next();
 });
 
-tagRouter.use("/", verifyToken.verifyToken());
+tagRouter.use("/", verifyToken.verifyToken(true));
 
-tagRouter.post("/subscribe", [verifyToken.verifyToken(true)], subscribeTag);
-tagRouter.delete(
-  "/unsubscribe",
-  [verifyToken.verifyToken(true), verifyRole.isManagerOrOwner],
-  unsubscribeTag
-);
+tagRouter.post("/subscribe", subscribeTag);
+tagRouter.delete("/unsubscribe", verifyRole.isManagerOrOwner, unsubscribeTag);
 
 export default tagRouter;

--- a/src/components/thread/threadController.js
+++ b/src/components/thread/threadController.js
@@ -8,7 +8,7 @@ export const getThreads = async (req, res) => {
     isResolved = null,
     channel = null,
     tag = null,
-    customer = null,
+    search = null,
   } = req.query;
   const { user } = req;
 
@@ -19,8 +19,8 @@ export const getThreads = async (req, res) => {
       limit: parseInt(limit),
       isResolved,
       channel,
-      tag,
-      customer,
+      tag: JSON.parse(tag),
+      search,
     });
 
     return res.status(200).json({

--- a/src/components/thread/threadService.js
+++ b/src/components/thread/threadService.js
@@ -100,95 +100,61 @@ export default class ThreadService {
     isResolved,
     channel,
     tag,
-    customer,
+    search,
   }) {
-    // Convert string to boolean if isResolved is not null
-    if (isResolved) {
-      isResolved = isResolved.toLowerCase() === "true";
-    }
-    if (channel && Number.isInteger(parseInt(channel))) {
-      channel = parseInt(channel);
-    }
-    let tagStr;
-    if (tag) {
-      tagStr = tag.map((t) => `tag_subscription.tag_id = ${t}`).join(" OR ");
-    }
-
-    const queryStr = `SELECT thread.*, 
-          t3.id AS 'customer.id',
-          t3.image_url AS 'customer.image_url',
-          t3.alias AS 'customer.alias',
-          t3.first_name AS 'customer.first_name',
-          t3.last_name AS 'customer.last_name',
-          t3.profile AS 'customer.profile',
-          t1.type AS 'channel_type',
-          t1.company_id AS 'company_id',
-          t2.id AS 'last_message.id',
-          t2.sender_type AS 'last_message.sender_type', 
-          t2.timestamp AS 'last_message.timestamp', 
-          t2.content AS 'last_message.content',
-          t2.sender_id AS 'last_message.sender.id',
-          t2.replied_message_id AS 'last_message.replied_message_id',
-          IF (t2.sender_type = 'customer', t3.first_name, t4.first_name) AS 'last_message.sender.first_name',
-          IF (t2.sender_type = 'customer', t3.last_name, t4.last_name) AS 'last_message.sender.last_name',
-          IF (t2.sender_type = 'customer', t3.image_url, t4.image_url) AS 'last_message.sender.image_url'
-        FROM thread
-        JOIN 
-        (
-          SELECT * FROM message
-          WHERE id IN (
-            SELECT MAX(id) FROM message
-            GROUP BY thread_id
-          )
-        ) AS t2 ON t2.thread_id = thread.id
-        LEFT JOIN customer AS t3 ON t3.thread_id = thread.id
-        LEFT JOIN user AS t4 ON t4.id = t2.sender_id
-      `;
-
-    const channelStr = channel
-      ? `
-      JOIN  
+    let query = `SELECT thread.*, 
+      t3.id AS 'customer.id',
+      t3.image_url AS 'customer.image_url',
+      t3.alias AS 'customer.alias',
+      t3.first_name AS 'customer.first_name',
+      t3.last_name AS 'customer.last_name',
+      t3.profile AS 'customer.profile',
+      t1.type AS 'channel_type',
+      t1.company_id AS 'company_id',
+      t2.id AS 'last_message.id',
+      t2.sender_type AS 'last_message.sender_type', 
+      t2.timestamp AS 'last_message.timestamp', 
+      t2.content AS 'last_message.content',
+      t2.sender_id AS 'last_message.sender.id',
+      t2.replied_message_id AS 'last_message.replied_message_id',
+      IF (t2.sender_type = 'customer', t3.first_name, t4.first_name) AS 'last_message.sender.first_name',
+      IF (t2.sender_type = 'customer', t3.last_name, t4.last_name) AS 'last_message.sender.last_name',
+      IF (t2.sender_type = 'customer', t3.image_url, t4.image_url) AS 'last_message.sender.image_url'
+      FROM thread
+      JOIN channel AS t1 ON t1.id = thread.channel_id 
+      JOIN 
       (
-		    SELECT * FROM channel where channel.id = ${channel}
-      )
-      AS t1 ON t1.id = thread.channel_id
-      `
-      : `JOIN channel AS t1 ON t1.id = thread.channel_id 
-      `;
-    const customerStr = customer
-      ? `AND t3.alias LIKE "%${customer}%"
-      `
-      : "";
-    const isResolvedStr =
-      isResolved != null
-        ? ` AND thread.is_resolved = ${isResolved}
-        `
-        : "";
-    const tagQuerryStr = tag
-      ? `JOIN ( SELECT DISTINCT customer_id FROM tag_subscription where `.concat(
-          tagStr,
-          `) AS t5 ON t5.customer_id = t3.id
-          `
+        SELECT * FROM message
+        WHERE id IN (
+          SELECT MAX(id) FROM message
+          GROUP BY thread_id
         )
-      : "";
+      ) AS t2 ON t2.thread_id = thread.id
+      LEFT JOIN customer AS t3 ON t3.thread_id = thread.id
+      LEFT JOIN user AS t4 ON t4.id = t2.sender_id
+      WHERE t1.company_id = :companyId`;
 
-    const filteredQuery = queryStr.concat(
-      channelStr,
-      tagQuerryStr,
-      `
-      WHERE t1.company_id = :companyId ${
-        lastThreadId ? `AND t2.id < :lastThreadId` : ""
-      } `,
-      isResolvedStr,
-      customerStr,
-      `ORDER BY t2.id DESC
-      LIMIT :limit;`
-    );
-    const threads = await sequelize.query(filteredQuery, {
+    if (lastThreadId) query += ` AND t2.id < :lastThreadId`;
+    if (isResolved) query += ` AND thread.is_resolved = :isResolved`;
+    if (channel) query += ` AND t1.id = :channel`;
+    if (search) {
+      query += ` AND (t3.alias LIKE :search OR CONCAT(customer.t3, " ", t3.last_name) LIKE :search`;
+      query += ` OR thread.id in (SELECT thread_id FROM message WHERE content LIKE :search))`;
+    }
+    if (tag)
+      query += ` AND t3.id IN (SELECT customer_id FROM tag_subscription WHERE tag_id = :tag)`;
+
+    query += ` ORDER BY t2.id DESC LIMIT :limit`;
+
+    const threads = await sequelize.query(query, {
       replacements: {
         companyId,
         lastThreadId,
         limit,
+        isResolved,
+        channel,
+        tag,
+        search: `%${search}%`,
       },
       type: sequelize.QueryTypes.SELECT,
       nest: true,

--- a/src/components/user/userController.js
+++ b/src/components/user/userController.js
@@ -2,13 +2,15 @@ import StatusEnum from "../../enums/Status.js";
 import UserService from "./userService.js";
 
 export const getCompanyMembers = async (req, res) => {
+  const { user } = req;
+
   try {
     const limit = parseInt(req.query.limit ?? 20, 10);
     const page = parseInt(req.query.page ?? 1, 10);
     const searchKey = req.query.searchKey ?? null;
 
     const members = await UserService.getCompanyMembers({
-      user: req.user,
+      companyId: user.company_id,
       limit,
       page,
       searchKey,

--- a/swagger_output.json
+++ b/swagger_output.json
@@ -1245,7 +1245,7 @@
             "type": "string"
           },
           {
-            "name": "customer",
+            "name": "search",
             "in": "query",
             "type": "string"
           }
@@ -1519,6 +1519,69 @@
             "in": "path",
             "required": true,
             "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/customer/tag/subscribe": {
+      "post": {
+        "tags": [
+          "Tag_subscription"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "customerId": {
+                  "example": "any"
+                },
+                "tagId": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/customer/tag/unsubscribe": {
+      "delete": {
+        "tags": [
+          "Tag_subscription"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "example": "any"
+                }
+              }
+            }
           }
         ],
         "responses": {
@@ -2000,69 +2063,6 @@
                   "example": "any"
                 },
                 "content": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/api/customer/tag/subscribe": {
-      "post": {
-        "tags": [
-          "Tag_subscription"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "customerId": {
-                  "example": "any"
-                },
-                "tagId": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/api/customer/tag/unsubscribe": {
-      "delete": {
-        "tags": [
-          "Tag_subscription"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
                   "example": "any"
                 }
               }


### PR DESCRIPTION
Don't use string concatenation with request param or body. It can be exploited by SQL injection.
Instead, use the 'replacements' in Sequelize.
